### PR TITLE
feat: add docker-compose configuration for production deploy

### DIFF
--- a/unicontract-docker/docker-compose.prod.yml
+++ b/unicontract-docker/docker-compose.prod.yml
@@ -42,6 +42,7 @@ services:
       - ../unicontract-mock-idp/start.js:/usr/src/app/start.js
     command: bash -c "node start.js"
 
+  # Comment this out to use Caddy instead of Nginx for out of the box HTTPS support
   nginx:
     build:
       context: ../unicontract-frontend
@@ -58,6 +59,30 @@ services:
       - ./docker-compose/nginx/conf.d/:/etc/nginx/conf.d/
     networks:
       - app-network
+
+  # Comment this out to use Nginx instead of Caddy
+  # caddy:
+  #   build:
+  #     context: ../unicontract-frontend
+  #     dockerfile: ../unicontract-docker/docker-compose/caddy/Dockerfile
+  #   ports:
+  #     - "80:80"
+  #     - "443:443"
+  #     - "443:443/udp"
+  #   volumes:
+  #     - ../unicontract-backend:${BASE_PATH}
+  #     - ./docker-compose/caddy/Caddyfile:/etc/caddy/Caddyfile:ro
+  #     - caddy_data:/data
+  #     - caddy_config:/config
+  #   depends_on:
+  #     - backend
+  #   networks:
+  #     - app-network
+  #   restart: unless-stopped
+
+volumes:
+  caddy_data:
+  caddy_config:
 
 networks:
   app-network:

--- a/unicontract-docker/docker-compose.prod.yml
+++ b/unicontract-docker/docker-compose.prod.yml
@@ -1,0 +1,64 @@
+services:
+  backend:
+    build:
+      context: ./docker-compose/php-fpm
+      dockerfile: Dockerfile
+      args:
+        user: enrico
+        uid: 1000
+        basepath: ${BASE_PATH}
+    image: unicontr
+    container_name: unicontr-backend
+    working_dir: ${BASE_PATH}
+    volumes:
+      - ../unicontract-backend:${BASE_PATH}
+    networks:
+      - app-network
+    depends_on:
+      - db
+
+  db:
+    image: mariadb:10.11
+    container_name: unicontr-db
+    restart: unless-stopped
+    environment:
+      MYSQL_DATABASE: unicontr
+      MYSQL_ROOT_PASSWORD: rootsecret
+      MYSQL_USER: unicontr
+      MYSQL_PASSWORD: secret
+    volumes:
+      - ./docker-compose/mysql/my.cnf:/etc/mysql/my.cnf
+    networks:
+      - app-network
+
+  idp:
+    build:
+      context: ../unicontract-mock-idp
+      dockerfile: ../unicontract-docker/docker-compose/mock-idp/Dockerfile
+    container_name: unicontr-idp
+    ports:
+      - "7000:7000"
+    volumes:
+      - ../unicontract-mock-idp/start.js:/usr/src/app/start.js
+    command: bash -c "node start.js"
+
+  nginx:
+    build:
+      context: ../unicontract-frontend
+      dockerfile: ../unicontract-docker/docker-compose/nginx/Dockerfile
+    container_name: unicontr-nginx
+    tty: true
+    restart: unless-stopped
+
+    ports:
+      - "80:80"
+      - "443:443"
+    volumes:
+      - ../unicontract-backend:${BASE_PATH}
+      - ./docker-compose/nginx/conf.d/:/etc/nginx/conf.d/
+    networks:
+      - app-network
+
+networks:
+  app-network:
+    driver: bridge

--- a/unicontract-docker/docker-compose/caddy/Caddyfile
+++ b/unicontract-docker/docker-compose/caddy/Caddyfile
@@ -1,0 +1,24 @@
+example.it, www.example.it {
+    route {
+        redir /public /public/
+
+        handle /public/* {
+            root * /var/www
+
+            @notStatic not file {path}
+            rewrite @notStatic /public/index.php
+
+            php_fastcgi backend:9000 {
+                root /var/www
+            }
+
+            file_server
+        }
+
+        handle {
+            root * /usr/share/caddy/frontend
+            try_files {path} {path}/ /index.html
+            file_server
+        }
+    }
+}

--- a/unicontract-docker/docker-compose/caddy/Dockerfile
+++ b/unicontract-docker/docker-compose/caddy/Dockerfile
@@ -1,0 +1,15 @@
+# Stage 1: build Angular
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build -- --configuration=production
+
+# Stage 2: serve with nginx
+FROM caddy:2
+
+COPY --from=builder /app/dist/UniContract-FrontEnd/browser/it /usr/share/caddy/frontend

--- a/unicontract-docker/docker-compose/nginx/Dockerfile
+++ b/unicontract-docker/docker-compose/nginx/Dockerfile
@@ -1,0 +1,15 @@
+# Stage 1: build Angular
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci
+
+COPY . .
+RUN npm run build -- --configuration=production
+
+# Stage 2: serve with nginx
+FROM nginx:alpine
+
+COPY --from=builder /app/dist/UniContract-FrontEnd/browser/it /usr/share/nginx/frontend

--- a/unicontract-docker/docker-compose/nginx/conf.d/default.conf
+++ b/unicontract-docker/docker-compose/nginx/conf.d/default.conf
@@ -3,8 +3,9 @@ server {
     index index.php index.html;
     error_log  /var/log/nginx/error.log;
     access_log /var/log/nginx/access.log;
-    root /var/www/public;
-    location ~ \.php$ {
+
+    location ~ ^/public/.*\.php$ {
+        root /var/www;
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
         fastcgi_pass backend:9000;
@@ -13,8 +14,15 @@ server {
         fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
         fastcgi_param PATH_INFO $fastcgi_path_info;
     }
-    location / {
-        try_files $uri $uri/ /index.php?$query_string;
+    location /public/ {
+        root /var/www;
+        try_files $uri $uri/ /public/index.php?$query_string;
         gzip_static on;
+    }
+
+    # Frontend app (Angular)
+    location / {
+        root /usr/share/nginx/frontend;
+        try_files $uri $uri/ /index.html;
     }
 }


### PR DESCRIPTION
- Build the frontend app with `ng build`
- Use Caddy for out-of-the-box https support